### PR TITLE
tailwindcssリメイク

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
 
-  <%= stylesheet_link_tag "application", "tailwind", "data-turbo-track": "reload" %>
+  <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
   <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   <%= javascript_include_tag "google_maps", type: "module" %>
   <style>


### PR DESCRIPTION
https://qiita.com/GandT/items/4b3701a6ca51ff84370c

という記事を参考に手直し、手直し前はうまくtailwindcssが反映されていないところがある

<原因>
rails assets:precompile` を実行してしまい以後アセットの更新が反映されなくなってしまった

<症状>
rails assets:precompile 実行後に作成されるプリコンパイル済みのアセットが存在する場合、表示においてそちらが優先される。これはプリコンパイル前のアセット（CSSやJavascript）が更新されてもそれらは無視されることを意味する。

<対策>
assetsを削除

docker compose run web rails assets:clobber

でassetsファイルは削除される

docker compose down して

docker compose build --no-cache

pcに残っているキャッシュを読み取らずにbuildさせる

docker compose up　

<備考>
自分の場合は

<%= stylesheet_link_tag "application","tailwind" "data-turbo-track": "reload" %>

という"tailwind" 　を記載すると反映されると思っていたが、間違い

<%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>

という元通りの状態で反映される

なお、自分はなかい講師の

https://hackmd.io/@SKjw2RY-RNCUNSdJfEWPig/HJE0GUClC

という記事のMySQL(Node.jsあり)　の Tailwind　という部分でrails new　した際に　Tailwindcss　を導入している