### PR TITLE
本番環境用にRAND()をRUNDOM()に変換

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,7 +2,7 @@ class PostsController < ApplicationController
   def index
     @posts = Post.page(params[:page]).per(12)
     # ピックアップ機能 Postモデルからランダムに3件の投稿を取得
-    @pick_up_posts = Post.order(Arel.sql('RAND()')).limit(3)
+    @pick_up_posts = Post.order(Arel.sql('RANDOM()')).limit(3)
   end
 
   def new


### PR DESCRIPTION
開発環境のmysqlでは. RAND()関数を使用してランダムな順序でレコードを選択できるが、PostgreSQLではRANDOM()関数を使用する必要があるため修正