### PR TITLE
AWS S3導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ gem "geocoder"
 # グーグルログインの開発環境と本番環境用でそれぞれ異なるurlにリダイレクトさせる
 gem 'config'
 
+# AWS S3 導入
+gem 'fog-aws'
+
 # Use Redis adapter to run Action Cable in production
 # gem "redis", ">= 4.0.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,12 +119,29 @@ GEM
       railties (>= 6.1)
     drb (2.2.1)
     erubi (1.12.0)
+    excon (0.110.0)
     faraday (2.9.0)
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
       net-http
     ffi (1.17.0-aarch64-linux-gnu)
     ffi (1.17.0-x86_64-linux-gnu)
+    fog-aws (3.23.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+    fog-core (2.4.0)
+      builder
+      excon (~> 0.71)
+      formatador (>= 0.2, < 2.0)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.4)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (1.1.0)
     geocoder (1.8.3)
       base64 (>= 0.1.0)
       csv (>= 3.0.0)
@@ -173,10 +190,14 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mime-types (3.5.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2024.0604)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     minitest (5.23.1)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
     mutex_m (0.2.0)
@@ -328,6 +349,7 @@ DEPENDENCIES
   cssbundling-rails
   debug
   dotenv-rails
+  fog-aws
   geocoder
   httparty
   jbuilder

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -5,8 +5,14 @@ class AvatarUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+
+
+  # AWS S3に本番環境で保存させて、ローカルではfileで保存
+  if Rails.env.production?
+    storage :fog # 本番環境ではfogを使用
+  else
+    storage :file # 開発環境とテスト環境ではfileを使用
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,16 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+CarrierWave.configure do |config|
+    config.storage :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_directory  = 'kodora'
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+      region: 'ap-northeast-1',
+      path_style: true
+    }
+end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -7,12 +7,12 @@ local:
   root: <%= Rails.root.join("storage") %>
 
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-# amazon:
-#   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-#   region: us-east-1
-#   bucket: your_own_bucket-<%= Rails.env %>
+ amazon:
+   service: S3
+   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
+   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
+   region: ap-northeast-1
+   bucket: your_own_bucket-<%= Rails.env %>
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
AWS S3　バケット作成
https://qiita.com/joinus_ibuki/items/050816c83234837167bc

本番環境への導入
https://qiita.com/iijima-naoya-45b/items/1b966b3152d4b0d73e49
https://qiita.com/joinus_ibuki/items/774a79e9c828ecdc57b3

を元に実装

アクセスキーの発行手順がわかりにくかったので

<アクセスキーの発行手順>
AWS Management Consoleにログイン:

AWSの管理コンソールにログインします。(パスワードなどを入れて)
IAMサービスに移動:

上部のナビゲーションバーで「Services」をクリックし、セキュリティ、ID、およびコンプライアンスのセクションから「IAM」を選択します。
ユーザーを選択:

左側のナビゲーションメニューから「ユーザー」をクリックします。
アクセスキーを発行したいユーザー名をクリックします。
セキュリティ資格情報タブを開く:

ユーザーの詳細ページで、「セキュリティ認証情報」タブをクリックします。
下へスクロールすると
アクセスキーの作成:　があるのでクリック

「アクセスキーの作成」ボタンをクリックし、表示されるユースケースの中から「5. AWS の外部で実行されるアプリケーション」を選択します。

次へをクリックすると


説明タグを設定 - オプション 情報
このアクセスキーの説明は、このユーザーにタグとしてアタッチされ、アクセスキーとともに表示されます。

説明タグ値
このアクセスキーの目的と使用場所を説明します。わかりやすい説明は、後でこのアクセスキーを確実にローテーションするのに役立ちます。
最大 256 文字です。使用できる文字は、UTF-8 で表現できる文字、数字、スペース、および _ . : / = + - @ です。


と出ます。
aws_s3_access_key　などと入力し、作成します。


アクセスキーIDとシークレットアクセスキーが表示されます。シークレットアクセスキーはこのときしか表示されないため、必ず安全な場所に保存してください。




あと、
gem "aws-sdk-s3", require: false
gem 'fog-aws'

というgemがありますが、

aws-sdk-s3　はs3のみを使う場合に記載、
gem 'fog-aws'　は色々使いたい時に実装

今回は後々拡張することも考え、gem 'fog-aws'　を採用